### PR TITLE
Add reverse transliteration variants

### DIFF
--- a/tests/translit_test.py
+++ b/tests/translit_test.py
@@ -20,6 +20,10 @@ from translitua.translit import (translit,
     RussianDriverLicense,
     RussianISO9SystemB,
     Lat2UkrKMU,
+    Lat2UkrSimple,
+    Lat2UkrWWS,
+    Lat2RuSimple,
+    Lat2RuISO9SystemB,
 )
 
 # ---------------------------------------------------------------------------
@@ -136,3 +140,49 @@ def test_russian_schemes(src, scheme, expected):
 )
 def test_positive(latin, expected):
     assert translit(latin, Lat2UkrKMU) == expected
+
+@pytest.mark.parametrize(
+    "latin,expected",
+    [
+        ("Kharkiv", "Харків"),
+        ("shch", "щ"),
+        ("ja", "я"),
+    ],
+)
+def test_lat2ukr_simple(latin, expected):
+    assert translit(latin, Lat2UkrSimple) == expected
+
+@pytest.mark.parametrize(
+    "latin,expected",
+    [
+        ("x", "х"),
+        ("šč", "щ"),
+        ("ž", "ж"),
+    ],
+)
+def test_lat2ukr_wws(latin, expected):
+    assert translit(latin, Lat2UkrWWS) == expected
+
+
+@pytest.mark.parametrize(
+    "latin,expected",
+    [
+        ("Shchuka", "Щука"),
+        ("Andrey", "Андрей"),
+        ("yozh", "ёж"),
+    ],
+)
+def test_lat2ru_simple(latin, expected):
+    assert translit(latin, Lat2RuSimple) == expected
+
+
+@pytest.mark.parametrize(
+    "latin,expected",
+    [
+        ("shh", "щ"),
+        ("e'", "э"),
+        ("y'", "ы"),
+    ],
+)
+def test_lat2ru_iso9b(latin, expected):
+    assert translit(latin, Lat2RuISO9SystemB) == expected

--- a/translitua/configs/reverse_ru.py
+++ b/translitua/configs/reverse_ru.py
@@ -1,0 +1,66 @@
+import re
+from translitua.tools import convert_table, add_uppercase
+
+
+class Lat2RuSimple(object):
+    """Reverse transliteration for :class:`RussianSimple`."""
+
+    _ONE_LETTER = {
+        "a": "а", "b": "б", "c": "к", "d": "д", "e": "е", "f": "ф",
+        "g": "г", "h": "х", "i": "и", "j": "й", "k": "к", "l": "л",
+        "m": "м", "n": "н", "o": "о", "p": "п", "q": "к", "r": "р",
+        "s": "с", "t": "т", "u": "у", "v": "в", "w": "в",
+        "x": "x", "y": "ы", "z": "з", "'": "ь",
+    }
+    MAIN_TRANSLIT_TABLE = convert_table(add_uppercase(_ONE_LETTER))
+
+    _SEQUENCES = {
+        "shch": "щ",
+        "sch": "щ",
+        "zh": "ж",
+        "kh": "х",
+        "ts": "ц",
+        "ch": "ч",
+        "sh": "ш",
+        "ju": "ю",
+        "ja": "я",
+        "yo": "ё",
+    }
+    SEQ_CASES = add_uppercase(_SEQUENCES)
+    PATTERN_SEQ = re.compile(r"(?i)" + "|".join(sorted(SEQ_CASES, key=len, reverse=True)))
+
+    PATTERN_Y_END = re.compile(r"(?i)y\b")
+    DELETE_PATTERN = re.compile(r"[\u0027\u2019\u02BC]")
+    LAT_RE = re.compile(r"[A-Za-z]")
+
+
+class Lat2RuISO9SystemB(object):
+    """Reverse transliteration for :class:`RussianISO9SystemB`."""
+
+    _ONE_LETTER = {
+        "a": "а", "b": "б", "v": "в", "g": "г", "d": "д", "e": "е",
+        "z": "з", "i": "и", "j": "й", "k": "к", "l": "л", "m": "м",
+        "n": "н", "o": "о", "p": "п", "r": "р", "s": "с", "t": "т",
+        "u": "у", "f": "ф", "x": "х", "y": "ы", "'": "ь",
+    }
+    MAIN_TRANSLIT_TABLE = convert_table(add_uppercase(_ONE_LETTER))
+
+    _SEQUENCES = {
+        "shh": "щ",
+        "zh": "ж",
+        "cz": "ц",
+        "ch": "ч",
+        "sh": "ш",
+        "yo": "ё",
+        "yu": "ю",
+        "ya": "я",
+        "e'": "э",
+        "y'": "ы",
+        "''": "ъ",
+    }
+    SEQ_CASES = add_uppercase(_SEQUENCES)
+    PATTERN_SEQ = re.compile(r"(?i)" + "|".join(sorted(SEQ_CASES, key=len, reverse=True)))
+
+    PATTERN_Y_END = re.compile(r"(?i)y\b")
+    LAT_RE = re.compile(r"[A-Za-z']")
+

--- a/translitua/configs/reverse_ua.py
+++ b/translitua/configs/reverse_ua.py
@@ -45,3 +45,57 @@ class Lat2UkrKMU(object):
 
     # 5. Латиниця, що лишилася після конверта — помилка у strict-режимі
     LAT_RE = re.compile(r"[A-Za-z]")
+class Lat2UkrSimple(object):
+    """Simplified reverse transliteration based on :class:`UkrainianSimple`."""
+
+    _ONE_LETTER = {
+        "a": "а", "b": "б", "c": "к", "d": "д", "e": "е", "f": "ф",
+        "g": "ґ", "h": "г", "i": "і", "j": "й", "k": "к", "l": "л",
+        "m": "м", "n": "н", "o": "о", "p": "п", "q": "к", "r": "р",
+        "s": "с", "t": "т", "u": "у", "v": "в", "w": "в",
+        "x": "x", "y": "и", "z": "з", "'": "ь",
+    }
+    MAIN_TRANSLIT_TABLE = convert_table(add_uppercase(_ONE_LETTER))
+
+    _SEQUENCES = {
+        "shch": "щ",
+        "zh": "ж",
+        "kh": "х",
+        "ts": "ц",
+        "ch": "ч",
+        "sh": "ш",
+        "ju": "ю",
+        "ja": "я",
+        "ye": "є",
+        "yi": "ї",
+    }
+    SEQ_CASES = add_uppercase(_SEQUENCES)
+    PATTERN_SEQ = re.compile(r"(?i)" + "|".join(sorted(SEQ_CASES, key=len, reverse=True)))
+
+    DELETE_PATTERN = re.compile(r"[\u0027\u2019\u02BC]")
+    LAT_RE = re.compile(r"[A-Za-z]")
+
+class Lat2UkrWWS(object):
+    """Reverse Scholarly (WWS) transliteration."""
+
+    _ONE_LETTER = {
+        "a": "а", "b": "б", "c": "ц", "d": "д", "e": "е", "f": "ф",
+        "g": "ґ", "h": "г", "i": "і", "j": "й", "k": "к", "l": "л",
+        "m": "м", "n": "н", "o": "о", "p": "п", "r": "р", "s": "с",
+        "t": "т", "u": "у", "v": "в", "x": "х", "y": "и", "z": "з",
+        "ž": "ж", "š": "ш", "č": "ч", "ʹ": "ь",
+    }
+    MAIN_TRANSLIT_TABLE = convert_table(add_uppercase(_ONE_LETTER))
+
+    _SEQUENCES = {
+        "šč": "щ",
+        "ju": "ю",
+        "ja": "я",
+        "je": "є",
+        "ji": "ї",
+    }
+    SEQ_CASES = add_uppercase(_SEQUENCES)
+    PATTERN_SEQ = re.compile(r"(?i)" + "|".join(sorted(SEQ_CASES, key=len, reverse=True)))
+
+    DELETE_PATTERN = re.compile(r"[\u0027\u2019\u02BC]")
+    LAT_RE = re.compile(r"[A-Za-z\u010D\u010F\u0111\u0161\u017E]")

--- a/translitua/translit.py
+++ b/translitua/translit.py
@@ -5,7 +5,8 @@ import sys
 
 # Припускаємо, що ці конфігурації правильно визначені та імпортовані
 # sys.path.append("./") # Якщо тести запускаються з кореневої папки, а translitua - підпапка
-from .configs.reverse_ua import Lat2UkrKMU
+from .configs.reverse_ua import Lat2UkrKMU, Lat2UkrSimple, Lat2UkrWWS
+from .configs.reverse_ru import Lat2RuSimple, Lat2RuISO9SystemB
 from .configs.ua import (
     UkrainianKMU,
     UkrainianSimple,
@@ -71,9 +72,11 @@ ALL_RUSSIAN = [
 # Backward compatibility
 RussianInternationalPassport = RussianInternationalPassport1997
 
-ALL_LATIN_TO_UKRAINIAN = [Lat2UkrKMU]
-
-ALL_TRANSLITERATIONS = ALL_UKRAINIAN + ALL_RUSSIAN + ALL_LATIN_TO_UKRAINIAN
+ALL_LATIN_TO_UKRAINIAN = [Lat2UkrKMU, Lat2UkrSimple, Lat2UkrWWS]
+ALL_LATIN_TO_RUSSIAN = [Lat2RuSimple, Lat2RuISO9SystemB]
+ALL_TRANSLITERATIONS = (
+    ALL_UKRAINIAN + ALL_RUSSIAN + ALL_LATIN_TO_UKRAINIAN + ALL_LATIN_TO_RUSSIAN
+)
 
 
 def translit(src, table=UkrainianKMU, preserve_case=True, strict=True):
@@ -243,6 +246,11 @@ __all__ = [
     "RussianISO9SystemA",
     "RussianISOR9Table2",
     "Lat2UkrKMU",
+    "Lat2UkrSimple",
+    "Lat2UkrWWS",
+    "Lat2RuSimple",
+    "Lat2RuISO9SystemB",
+    "ALL_LATIN_TO_RUSSIAN",
 ]
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support Lat2UkrSimple and Lat2UkrWWS configurations
- expose them via translit module
- cover new variants with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f4e44c50883309802cddea7b269ed