### PR TITLE
Add documentation for Latin-to-Cyrillic tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # translit-ua
 
+[Версія українською](README.ua.md)
+
 
 Transliteration (romanization, latinization) for Ukrainian and russian languages with various transliteration tables (including official ones).
 Translit-ua has 13 transliteration tables for the Ukrainian language:
@@ -32,6 +34,13 @@ Translit-ua also has 10 transliteration tables for the russian language:
 - RussianISO9SystemB (ISO 9:1995, System B, no diacritics)
 
 
+Translit-ua can also transliterate *from* Latin back to Cyrillic.  For
+Ukrainian there are tables `Lat2UkrKMU`, `Lat2UkrSimple` and
+`Lat2UkrWWS`, while for Russian there are `Lat2RuSimple` and
+`Lat2RuISO9SystemB`.  They are grouped in
+`ALL_LATIN_TO_UKRAINIAN` and `ALL_LATIN_TO_RUSSIAN` respectively.
+
+
 The minor difference in those tables is that the common apostrophe sign ' is used in every table.
 
 For convenience, all Ukrainian tables are listed in ALL_UKRAINIAN variable, and all russian tables are listed in ALL_RUSSIAN variable. In ALL_TRANSLITERATIONS variable, you might find the complete list of tables.
@@ -40,7 +49,13 @@ Translit-ua works with python 2.6+ and python 3+ and has good doctests coverage.
 
 ## Installation
 
-Install from PyPI.
+Install the latest version directly from GitHub:
+
+```bash
+$ pip install git+https://github.com/dimabendera/translit-ua.git
+```
+
+You can also install the library from PyPI as usual:
 
 ```bash
 $ pip install translitua
@@ -68,6 +83,17 @@ $ pip install translitua
     Только в уборную - и сразу же возвращайся.""", RussianSimple
     )
     u"Ne vyhodi iz komnaty, ne sovershaj oshibku.\nZachem tebe Solntse, esli ty kurish' Shipku?\nZa dver'ju bessmyslenno vse, osobenno - vozglas schast'ja.\nTol'ko v ubornuju - i srazu zhe vozvraschajsja."
+
+    >>> from translitua import Lat2UkrKMU
+    >>> translit("Kharkiv", Lat2UkrKMU)
+    'Харків'
+
+    >>> from translitua import Lat2RuSimple
+    >>> translit("SCHUKA", Lat2RuSimple)
+    'ЩУКА'
+
+    >>> translit("ЗГУРОВСЬКИЙ", preserve_case=False)
+    'ZGhUROVSKYI'
 ```
 
 More about [Ukrainian transliteration](https://en.wikipedia.org/wiki/Romanization_of_Ukrainian)

--- a/README.ua.md
+++ b/README.ua.md
@@ -1,0 +1,70 @@
+# translit-ua
+
+Цей проект надає офіційну транслітерацію для української та російської мов. Він містить різні таблиці транслітерації (включно з офіційними).
+
+## Таблиці транслітерації української мови
+
+- UkrainianKMU (Національна 2010, чинна постанова Кабміну)
+- UkrainianSimple (спрощена)
+- UkrainianWWS (Woodrow Wilson School)
+- UkrainianBritish (британський стандарт)
+- UkrainianBGN (BGN/PGGN 1965)
+- UkrainianISO9 (ISO 9)
+- UkrainianFrench (Jean Girodet, 1976)
+- UkrainianGerman (Duden, 2000)
+- UkrainianGOST1971 (ГОСТ СРСР 1971)
+- UkrainianGOST1986 (ГОСТ СРСР 1986)
+- UkrainianPassport2007 (паспорт 2007–2010 рр.)
+- UkrainianNational1996 (Комітет з питань правничої термінології, 1996)
+- UkrainianPassport2004Alt (альтернативна таблиця 2004–2007 рр.)
+
+## Таблиці транслітерації російської мови
+
+- RussianGOST2006 (ГОСТ РФ 2006)
+- RussianSimple (спрощена)
+- RussianICAO (ICAO DOC9303)
+- RussianTelegram (телеграми 2001)
+- RussianInternationalPassport1997 (міжнародний паспорт 1997–2010)
+- RussianInternationalPassport1997Reduced (те ж, з редукцією yy → y)
+- RussianDriverLicense (водійські посвідчення від 2000 р.)
+- RussianISOR9Table2 (ISO/R 9 (1968), таблиця 2)
+- RussianISO9SystemA (ISO 9:1995, система A)
+- RussianISO9SystemB (ISO 9:1995, система B)
+
+
+Крім таблиць для транслітерації з кирилиці у латиницю, пакет також надає
+конфігурації для зворотного напрямку. Для української це
+`Lat2UkrKMU`, `Lat2UkrSimple` та `Lat2UkrWWS`, а для російської —
+`Lat2RuSimple` і `Lat2RuISO9SystemB`. Вони згруповані у списках
+`ALL_LATIN_TO_UKRAINIAN` та `ALL_LATIN_TO_RUSSIAN`.
+
+Можна використовувати всі таблиці з `ALL_UKRAINIAN`, `ALL_RUSSIAN` та `ALL_TRANSLITERATIONS`.
+
+## Встановлення
+
+Встановити останню версію можна безпосередньо з GitHub:
+
+```bash
+pip install git+https://github.com/dimabendera/translit-ua.git
+```
+
+Або встановіть версію з PyPI:
+
+```bash
+pip install translitua
+```
+
+## Приклади використання
+
+```python
+from translitua import translit, UkrainianKMU, Lat2UkrKMU
+
+print(translit("Дмитро Згуровський", UkrainianKMU))
+# Dmytro Zghurovskyi
+
+print(translit("Kharkiv", Lat2UkrKMU))
+# Харків
+```
+
+Більше інформації про [українську транслітерацію](https://uk.wikipedia.org/wiki/%D0%A0%D0%BE%D0%BC%D0%B0%D0%BD%D1%96%D0%B7%D0%B0%D1%86%D1%96%D1%8F_%D1%83%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%BE%D1%97_%D0%BC%D0%BE%D0%B2%D0%B8)
+і [російську транслітерацію](https://uk.wikipedia.org/wiki/%D0%A2%D1%80%D0%B0%D0%BD%D1%81%D0%BB%D1%96%D1%82%D0%B5%D1%80%D0%B0%D1%86%D1%96%D1%8F_%D1%80%D0%BE%D1%81%D1%96%D0%B9%D1%81%D1%8C%D0%BA%D0%BE%D0%B3%D0%BE_%D0%B0%D0%BB%D1%84%D0%B0%D0%B2%D1%96%D1%82%D1%83_%D0%BB%D0%B0%D1%82%D0%B8%D0%BD%D0%B8%D1%86%D0%B5%D1%8E).


### PR DESCRIPTION
## Summary
- document reverse transliteration classes in README
- add the same information to the Ukrainian translation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f588e0da88330a1482a6dd3afe0e2